### PR TITLE
Removed require pry

### DIFF
--- a/lib/html_aide/tag.rb
+++ b/lib/html_aide/tag.rb
@@ -1,4 +1,3 @@
-require 'pry'
 module HtmlAide
   class Tag
     VALID_TAGS = %w(


### PR DESCRIPTION
Requiring pry here caused us problems. Pry is normally only included in the stack in dev and test, so when deploying to a production or UAT environment this can cause problems.